### PR TITLE
Fix: Restore granted cards on page reload

### DIFF
--- a/moves/inline-cards.js
+++ b/moves/inline-cards.js
@@ -13,8 +13,13 @@ window.InlineCards = (function() {
      * @param {string} className - CSS class for the card wrapper (optional)
      */
     async function displayCard(containerId, cardId, className = 'granted-card') {
+        console.log(`displayCard: containerId=${containerId}, cardId=${cardId}`);
         const container = document.getElementById(containerId);
-        if (!container || !cardId) return;
+        console.log(`displayCard: container found:`, container);
+        if (!container || !cardId) {
+            console.log(`displayCard: Missing container or cardId - container: ${container}, cardId: ${cardId}`);
+            return;
+        }
 
         try {
             if (window.Cards) {
@@ -91,6 +96,9 @@ window.InlineCards = (function() {
      * @param {boolean} isChecked - Whether the move is checked
      */
     function toggleCardDisplay(moveId, cardId, containerId, isChecked) {
+        console.log(`toggleCardDisplay: moveId=${moveId}, cardId=${cardId}, containerId=${containerId}, isChecked=${isChecked}`);
+        const container = document.getElementById(containerId);
+        console.log(`toggleCardDisplay: container found:`, container);
         if (isChecked) {
             displayCard(containerId, cardId);
         } else {

--- a/moves/moves-core.js
+++ b/moves/moves-core.js
@@ -143,16 +143,9 @@ window.MovesCore = (function() {
         const containerId = `granted_card_${move.id}`;
         const cardSection = window.InlineCards.createCardContainer(containerId, "Grants:");
         
-        // Use the existing isMoveTaken function to check if move is selected
-        const isTaken = isMoveTaken(move, urlParams);
-        
-        if (isTaken) {
-            // Show the card immediately if taken
-            window.InlineCards.displayCard(containerId, move.grantsCard);
-        } else {
-            // Hide initially
-            cardSection.style.display = 'none';
-        }
+        // Don't show the card immediately during render - let restoreGrantedCards handle it
+        // This prevents timing issues where the container exists but DOM isn't fully ready
+        cardSection.style.display = 'none';
         
         return cardSection;
     }

--- a/moves/moves.js
+++ b/moves/moves.js
@@ -98,13 +98,36 @@ window.Moves = (function() {
                     // Add a small delay to ensure DOM is fully updated
                     setTimeout(() => {
                         window.Persistence.refreshPersistence(form);
+                        // After persistence is refreshed, restore any granted cards
+                        restoreGrantedCards();
                     }, 50);
                 }
             }
         }
     }
 
-
+    /**
+     * Restore granted cards for checked moves after persistence load
+     * This is needed because card display only happens on change events,
+     * not when checkboxes are programmatically set during persistence restoration
+     */
+    function restoreGrantedCards() {
+        if (!window.moves) return;
+        
+        // Find all moves that grant cards
+        const cardGrantingMoves = window.moves.filter(move => move.grantsCard);
+        
+        cardGrantingMoves.forEach(move => {
+            const checkbox = document.getElementById(`move_${move.id}`);
+            if (checkbox && checkbox.checked) {
+                // This move is checked and grants a card - display the card
+                const containerId = `granted_card_${move.id}`;
+                if (window.InlineCards) {
+                    window.InlineCards.toggleCardDisplay(move.id, move.grantsCard, containerId, true);
+                }
+            }
+        });
+    }
 
     // Public API
     return {

--- a/moves/moves.js
+++ b/moves/moves.js
@@ -98,8 +98,10 @@ window.Moves = (function() {
                     // Add a small delay to ensure DOM is fully updated
                     setTimeout(() => {
                         window.Persistence.refreshPersistence(form);
-                        // After persistence is refreshed, restore any granted cards
-                        restoreGrantedCards();
+                        // After persistence is refreshed, restore any granted cards with additional delay
+                        setTimeout(() => {
+                            restoreGrantedCards();
+                        }, 100);
                     }, 50);
                 }
             }
@@ -112,21 +114,31 @@ window.Moves = (function() {
      * not when checkboxes are programmatically set during persistence restoration
      */
     function restoreGrantedCards() {
-        if (!window.moves) return;
+        console.log('restoreGrantedCards: Starting restoration');
+        if (!window.moves) {
+            console.log('restoreGrantedCards: No moves data available');
+            return;
+        }
         
         // Find all moves that grant cards
         const cardGrantingMoves = window.moves.filter(move => move.grantsCard);
+        console.log('restoreGrantedCards: Found card-granting moves:', cardGrantingMoves.map(m => ({id: m.id, grantsCard: m.grantsCard})));
         
         cardGrantingMoves.forEach(move => {
             const checkbox = document.getElementById(`move_${move.id}`);
+            console.log(`restoreGrantedCards: Checking move ${move.id}, checkbox:`, checkbox, 'checked:', checkbox ? checkbox.checked : 'N/A');
             if (checkbox && checkbox.checked) {
                 // This move is checked and grants a card - display the card
                 const containerId = `granted_card_${move.id}`;
+                console.log(`restoreGrantedCards: Restoring card ${move.grantsCard} for move ${move.id} in container ${containerId}`);
                 if (window.InlineCards) {
                     window.InlineCards.toggleCardDisplay(move.id, move.grantsCard, containerId, true);
+                } else {
+                    console.log('restoreGrantedCards: InlineCards not available');
                 }
             }
         });
+        console.log('restoreGrantedCards: Restoration complete');
     }
 
     // Public API


### PR DESCRIPTION
- Cards granted by moves (like Animal Companion) now properly display after page reload
- Added restoreGrantedCards() function to check for checked moves that grant cards
- Called after persistence restoration to ensure cards display correctly
- Fixes issue where cards only displayed on first checkbox toggle, not on reload